### PR TITLE
88 - update np.float to float to avoid deprecation warning

### DIFF
--- a/mapreader/download/tileserver_access.py
+++ b/mapreader/download/tileserver_access.py
@@ -88,7 +88,7 @@ class TileServer:
             # Collect boundaries for fast queries
             metadata_coord_arr.append([min_lon, max_lon, min_lat, max_lat])
         self.metadata_info_list = metadata_info_list
-        self.metadata_coord_arr = np.array(metadata_coord_arr).astype(np.float)
+        self.metadata_coord_arr = np.array(metadata_coord_arr).astype(float)
         self.detected_rect_boundary = True
 
     def modify_metadata(self, remove_image_ids=[], only_keep_image_ids=[]):


### PR DESCRIPTION
### Summary

`np.float` has been deprecated but is used in our code so should be updated to standard python `float`.
Fixes #88 

### Describe your changes
  
Change instance of `np.float` to just `float`

### Checklist before assigning a reviewer (update as needed)
  
- [x ] Ensure submission passes current tests
  
### Reviewer checklist

- [ ] Everything looks ok?
