### PR TITLE
fix bug where classifier.show_sample() always prints batch_info for 'train' dataset

### DIFF
--- a/mapreader/train/classifier.py
+++ b/mapreader/train/classifier.py
@@ -1001,7 +1001,7 @@ class classifier:
         """
         if print_batch_info:
             # print info about batch size
-            self.batch_info()
+            self.batch_info(set_name)
 
         dl_iter = iter(self.dataloader[set_name])
         for _ in range(batch_number):


### PR DESCRIPTION
### Summary

As per #71 - `classfier.show_sample()` always prints batch_info corresponding to 'train' dataset irregardless of samples being shown

e.g. (should print batch info for 'val' dataset)
 ![image](https://user-images.githubusercontent.com/72076688/222198307-5c50f9b7-f07a-4e19-a7e1-1f2e7a5aad1a.png)

Fixes #71

### Describe your changes
  
Added 'set_name' argument when calling `.batch_info()` as part of `.show_sample()` method. 
`.batch_info()` -> `.batch_info(set_name).`

### Checklist before assigning a reviewer (update as needed)
  
- [x] Self-review code
- [x] Ensure submission passes current tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
