### PR TITLE
Fix codecov badge

### DIFF
--- a/.github/workflows/mr_ci_text_spotting.yml
+++ b/.github/workflows/mr_ci_text_spotting.yml
@@ -71,7 +71,7 @@ jobs:
           python -m pytest --cov=./ --cov-report=xml ./tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/reports/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Integration Tests badge](https://github.com/Living-with-machines/MapReader/actions/workflows/mr_ci.yml/badge.svg)
 ![DOI](https://zenodo.org/badge/430661738.svg)
-![CodeCov](https://codecov.io/github/Living-with-machines/MapReader/graph/badge.svg?token=38GQ3O1GB5)
+[![codecov](https://codecov.io/gh/maps-as-data/MapReader/graph/badge.svg?token=38GQ3O1GB5)](https://codecov.io/gh/maps-as-data/MapReader)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.06434/status.svg)](https://doi.org/10.21105/joss.06434)
 
 ## Table of Contents


### PR DESCRIPTION
Fixes the codecov badge in the README.
Also updates codecov action to v5

Fixes #526 