### PR TITLE
Bug fix explore methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The following table shows which versions of MapReader are compatible with which 
 
 _Add new changes here_
 
+### Fixed
+- Fixes the `explore_predictions` and `explore_search_results` methods in the `DeepSoloRunner` and `MapTextRunner` classes ([#544](https://github.com/maps-as-data/MapReader/pull/544))
+
 ## [v1.6.2](https://github.com/Living-with-machines/MapReader/releases/tag/v1.6.2) (2025-01-02)
 
 ### Added

--- a/mapreader/spot_text/runner_base.py
+++ b/mapreader/spot_text/runner_base.py
@@ -672,6 +672,9 @@ class DetRunner:
             tiles = xyz.providers.OpenStreetMap.Mapnik
 
         preds_df = self._dict_to_dataframe(self.geo_predictions)
+        preds_df.drop(
+            columns=["pixel_geometry"], inplace=True
+        )  # drop pixel_geometry since we can't have two polygon columns
 
         return preds_df[preds_df["image_id"] == parent_id].explore(
             tiles=tiles,
@@ -1059,6 +1062,9 @@ class DetRecRunner(DetRunner):
 
         geo_search_results = self._get_geo_search_results()
         geo_df = self._dict_to_dataframe(geo_search_results)
+        geo_df.drop(
+            columns=["pixel_geometry"], inplace=True
+        )  # drop pixel_geometry since we can't have two polygon columns
 
         return geo_df[geo_df["image_id"] == parent_id].explore(
             tiles=tiles,


### PR DESCRIPTION
### Summary

This fixes a bug in the explore_predictions and explore_search_results methods caused by having both pixel and geo coordinates in our geodataframe. 

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests
- [ ] Add tests
- [ ] Update relevant docs
- [x] Update changelog

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
