### PR TITLE
Update text spotting to keep lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The following table shows which versions of MapReader are compatible with which 
 ---
 
 ## Pre-release
+### Added
+
+- Center lines are now stored for each text instance as a LineString ([#559](https://github.com/maps-as-data/MapReader/pull/559))
 
 ### Removed
 

--- a/mapreader/spot_text/dataclasses.py
+++ b/mapreader/spot_text/dataclasses.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from shapely.geometry import Polygon
+from shapely.geometry import LineString, Polygon
 
 
 @dataclass(frozen=True)
 class PatchPrediction:
     pixel_geometry: Polygon
+    pixel_line: LineString
     score: float
     text: str = None
 
@@ -15,6 +16,7 @@ class PatchPrediction:
 @dataclass(frozen=True)
 class ParentPrediction:
     pixel_geometry: Polygon
+    pixel_line: LineString
     score: float
     patch_id: str
     text: str = None
@@ -23,8 +25,10 @@ class ParentPrediction:
 @dataclass(frozen=True)
 class GeoPrediction:
     pixel_geometry: Polygon
+    pixel_line: LineString
     score: float
     patch_id: str
     geometry: Polygon
+    line: LineString
     crs: str
     text: str = None

--- a/mapreader/spot_text/dptext_detr_runner.py
+++ b/mapreader/spot_text/dptext_detr_runner.py
@@ -124,5 +124,5 @@ class DPTextDETRRunner(DetRunner):
             score = f"{score:.2f}"
 
             self.patch_predictions[image_id].append(
-                PatchPrediction(pixel_geometry=polygon, score=score)
+                PatchPrediction(pixel_geometry=polygon, pixel_line=None, score=score)
             )

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
             "pytest<9.0.0",
             "pytest-cov>=4.1.0,<6.0.0",
             "timm<1.0.0",
-            "transformers<5.0.0",
+            "transformers<5.0.0, !=4.50.0",
             "black>=23.7.0,<25.0.0",
             "flake8>=6.0.0,<8.0.0",
         ],

--- a/tests/test_text_spotting/test_maptext_runner.py
+++ b/tests/test_text_spotting/test_maptext_runner.py
@@ -230,7 +230,9 @@ def test_maptext_run_all(init_runner, mock_response):
     # dataframe
     out = runner._dict_to_dataframe(runner.patch_predictions)
     assert isinstance(out, pd.DataFrame)
-    assert set(out.columns) == set(["image_id", "pixel_geometry", "text", "score"])
+    assert set(out.columns) == set(
+        ["image_id", "pixel_geometry", "pixel_line", "text", "score"]
+    )
     assert "patch-0-0-800-40-#mapreader_text.png#.png" in out["image_id"].values
 
 
@@ -246,7 +248,7 @@ def test_maptext_convert_to_parent(runner_run_all, mock_response):
     out = runner._dict_to_dataframe(runner.parent_predictions)
     assert isinstance(out, pd.DataFrame)
     assert set(out.columns) == set(
-        ["image_id", "patch_id", "pixel_geometry", "text", "score"]
+        ["image_id", "patch_id", "pixel_geometry", "pixel_line", "text", "score"]
     )
     assert "mapreader_text.png" in out["image_id"].values
 
@@ -263,7 +265,16 @@ def test_maptext_convert_to_parent_coords(runner_run_all, mock_response):
     out = runner._dict_to_dataframe(runner.geo_predictions)
     assert isinstance(out, gpd.GeoDataFrame)
     assert set(out.columns) == set(
-        ["image_id", "patch_id", "pixel_geometry", "geometry", "crs", "text", "score"]
+        [
+            "image_id",
+            "patch_id",
+            "pixel_geometry",
+            "pixel_line",
+            "geometry",
+            "crs",
+            "text",
+            "score",
+        ]
     )
     assert "mapreader_text.png" in out["image_id"].values
     assert out.crs == runner.parent_df.crs
@@ -314,7 +325,17 @@ def test_maptext_to_geojson(runner_run_all, tmp_path, mock_response):
     gdf = gpd.read_file(f"{tmp_path}/text.geojson")
     assert isinstance(gdf, gpd.GeoDataFrame)
     assert set(gdf.columns) == set(
-        ["image_id", "patch_id", "pixel_geometry", "geometry", "crs", "text", "score"]
+        [
+            "image_id",
+            "patch_id",
+            "pixel_geometry",
+            "pixel_line",
+            "geometry",
+            "line",
+            "crs",
+            "text",
+            "score",
+        ]
     )
 
 
@@ -328,7 +349,7 @@ def test_maptext_search_predictions(runner_run_all, mock_response):
     out = runner.search_predictions("map", ignore_case=True, return_dataframe=True)
     assert isinstance(out, pd.DataFrame)
     assert set(out.columns) == set(
-        ["image_id", "patch_id", "pixel_geometry", "text", "score"]
+        ["image_id", "patch_id", "pixel_geometry", "pixel_line", "text", "score"]
     )
     assert "mapreader_text.png" in out["image_id"].values
     out = runner.search_predictions(
@@ -353,7 +374,17 @@ def test_maptext_search_results(runner_run_all, tmp_path, mock_response):
     gdf = gpd.read_file(f"{tmp_path}/search_results.geojson")
     assert isinstance(gdf, gpd.GeoDataFrame)
     assert set(gdf.columns) == set(
-        ["image_id", "patch_id", "pixel_geometry", "geometry", "crs", "text", "score"]
+        [
+            "image_id",
+            "patch_id",
+            "pixel_geometry",
+            "pixel_line",
+            "geometry",
+            "line",
+            "crs",
+            "text",
+            "score",
+        ]
     )
     assert "mapreader_text.png" in gdf["image_id"].values
 


### PR DESCRIPTION
### Summary
This PR adds central line data to the text outputs.

### Describe your changes

Adds line as `pixel_line` and `line` for the `pixel_geometry` and `geometry` polygons respectively.

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests
- [x] Add tests
- [ ] Update relevant docs
- [ ] Update changelog

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
